### PR TITLE
unfavorite non-runnable subtree to pass CI validation

### DIFF
--- a/src/phoebe_sim/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
+++ b/src/phoebe_sim/objectives/segment_image_from_no_negative_text_prompt_subtree.xml
@@ -7,7 +7,6 @@
   <BehaviorTree
     ID="Segment Image from No Negative Text Prompt Subtree"
     _description="Run text based segmentation and visualize the masks."
-    _favorite="true"
   >
     <Control ID="Sequence">
       <Action


### PR DESCRIPTION
Update the branch we are using for example_ws to fix a favorited subtree, which doesn't pass Objective validation