### PR TITLE
refactor(objectives): replace CreateStampedPose with CreatePoseStamped

### DIFF
--- a/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
@@ -4,13 +4,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -18,18 +18,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;-0.15;0"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -37,7 +37,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
@@ -4,13 +4,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -18,18 +18,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0.5;0.17;-0.18"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -37,7 +37,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
@@ -4,18 +4,18 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{init_stamped_pose}"
+          pose_stamped="{init_pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{init_stamped_pose}"
+          input="{init_pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
       </Control>
@@ -65,8 +65,8 @@
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
       <inout_port
-        name="stamped_pose"
-        default="{stamped_pose}"
+        name="pose_stamped"
+        default="{pose_stamped}"
         type="geometry_msgs::msg::PoseStamped_&lt;std::allocator&lt;void&gt; &gt;"
       >
         moves both arms with the given transform(trajectory relative to left

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
@@ -5,13 +5,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -19,18 +19,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;0;0"
           orientation_xyzw="0.0;0.0;0.707;0.707"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_move_up_and_push.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_move_up_and_push.xml
@@ -92,23 +92,23 @@
       <!--Move right arm out of the way-->
       <SubTree ID="Open Right Gripper" _collapsed="true" />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="right_grasp_link"
         position_xyz="0;0;-0.2"
-        stamped_pose="{stamped_pose}"
+        pose_stamped="{pose_stamped}"
       />
       <Action
         ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
+        input="{pose_stamped}"
         vector="{pose_stamped_vector}"
       />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="right_grasp_link"
         position_xyz="0.3;0;-0.2"
-        stamped_pose="{stamped_pose}"
+        pose_stamped="{pose_stamped}"
       />
-      <Action ID="AddPoseStampedToVector" input="{stamped_pose}" />
+      <Action ID="AddPoseStampedToVector" input="{pose_stamped}" />
       <Action
         ID="VisualizePose"
         marker_lifetime="0.000000"

--- a/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
@@ -10,14 +10,14 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           _skipIf="true"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
           _skipIf="true"
         />
@@ -26,19 +26,19 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
           _skipIf="true"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;-0.17;0"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -46,7 +46,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"


### PR DESCRIPTION
## Summary

- Replaces all `CreateStampedPose` usages with `CreatePoseStamped` across 6 phoebe_sim objectives, matching the MoveIt Pro 9.3 deprecation (see [example_ws#623](https://github.com/PickNikRobotics/moveit_pro_example_ws/pull/623))
- Renames the output port attribute `stamped_pose=` → `pose_stamped=` and updates all downstream blackboard key references `{stamped_pose}` → `{pose_stamped}` within each objective
- Resolves the missing `pose=` binding bug on the third `VisualizePose` in `multi-tip_path_re-orient_move_up_and_push.xml`: `CreatePoseStamped` now writes `{pose_stamped}`, which matches `VisualizePose`'s default port key, so no explicit binding is needed (this supersedes the approach in the reverted PR #18)

## Files changed

- `multi-tip_path_re-orient_bottle.xml`
- `multi-tip_path_move_up_bottle.xml`
- `multi-tip_path_move_push_bottle.xml`
- `multi-tip_path_move_with_pose.xml` (also renames subtree port `stamped_pose` → `pose_stamped`)
- `multi-tip_path_re-orient_move_up_and_push.xml`
- `single-tip_path_admittance_move_push_bottle.xml`

## Test plan

- [ ] Run Multi-tip Path Re-Orient Bottle in lunar_sim — verify no deprecation warnings and VisualizePose markers appear
- [ ] Run Multi-tip Path Move Up Bottle in lunar_sim
- [ ] Run Multi-tip Path Move Push Bottle in lunar_sim
- [ ] Run Multi-tip Path Re-Orient, Move Up and Push in lunar_sim end-to-end
- [ ] Run Single-tip Path Admittance Move Push Bottle in lunar_sim
- [ ] Run Multi-tip Path Move With Pose in lunar_sim (pass a `pose_stamped` input)

🤖 Generated with [Claude Code](https://claude.com/claude-code)