### PR TITLE
fix(objectives): unfavorite single-tip admittance push and add description warning

### DIFF
--- a/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
@@ -5,7 +5,8 @@
 >
   <BehaviorTree
     ID="Single-tip Path Admittance Move Push Bottle"
-    _description=""
+    _description="Requires a bottle in the scene — will time out without one. Performs a force-controlled admittance push with the left arm."
+    _favorite="false"
   >
     <Control ID="Sequence">
       <Control ID="Sequence">


### PR DESCRIPTION
## Summary
- Adds a description to `Single-tip Path Admittance Move Push Bottle` warning that it requires a bottle in the scene and will time out without one
- Sets `_favorite="false"` to hide it from the top-level favorites list

## Context
This objective uses force-controlled admittance execution with `goal_duration_tolerance="30.000000"`. Without a bottle to provide force feedback, it times out and leaves `left_manipulator_joint_trajectory_admittance_controller` active with an in-progress goal. Any subsequent `SwitchController` call then fails with "Can't deactivate controller because there's an active goal."

Related issue: https://github.com/PickNikRobotics/moveit_pro/issues/19126

## Test plan
- [ ] Run the objective with a bottle in the scene — should execute normally
- [ ] Verify the objective no longer appears in the favorites list
- [ ] Verify the description warning is visible in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)