### PR TITLE
for main, refactor(objectives): replace CreateStampedPose with CreatePoseStamped

### DIFF
--- a/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
@@ -4,13 +4,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -18,18 +18,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;-0.15;0"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -37,7 +37,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
@@ -4,13 +4,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -18,18 +18,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0.5;0.17;-0.18"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -37,7 +37,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
@@ -4,18 +4,18 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{init_stamped_pose}"
+          pose_stamped="{init_pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{init_stamped_pose}"
+          input="{init_pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
       </Control>
@@ -65,8 +65,8 @@
         <Metadata subcategory="Application - Advanced Examples" />
       </MetadataFields>
       <inout_port
-        name="stamped_pose"
-        default="{stamped_pose}"
+        name="pose_stamped"
+        default="{pose_stamped}"
         type="geometry_msgs::msg::PoseStamped_&lt;std::allocator&lt;void&gt; &gt;"
       >
         moves both arms with the given transform(trajectory relative to left

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
@@ -5,13 +5,13 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -19,18 +19,18 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;0;0"
           orientation_xyzw="0.0;0.0;0.707;0.707"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_move_up_and_push.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_move_up_and_push.xml
@@ -92,23 +92,23 @@
       <!--Move right arm out of the way-->
       <SubTree ID="Open Right Gripper" _collapsed="true" />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="right_grasp_link"
         position_xyz="0;0;-0.2"
-        stamped_pose="{stamped_pose}"
+        pose_stamped="{pose_stamped}"
       />
       <Action
         ID="AddPoseStampedToVector"
-        input="{stamped_pose}"
+        input="{pose_stamped}"
         vector="{pose_stamped_vector}"
       />
       <Action
-        ID="CreateStampedPose"
+        ID="CreatePoseStamped"
         reference_frame="right_grasp_link"
         position_xyz="0.3;0;-0.2"
-        stamped_pose="{stamped_pose}"
+        pose_stamped="{pose_stamped}"
       />
-      <Action ID="AddPoseStampedToVector" input="{stamped_pose}" />
+      <Action ID="AddPoseStampedToVector" input="{pose_stamped}" />
       <Action
         ID="VisualizePose"
         marker_lifetime="0.000000"

--- a/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
@@ -10,14 +10,14 @@
     <Control ID="Sequence">
       <Control ID="Sequence">
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           _skipIf="true"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
           _skipIf="true"
         />
@@ -26,19 +26,19 @@
           marker_lifetime="0.000000"
           marker_name="pose"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
           _skipIf="true"
         />
         <Action
-          ID="CreateStampedPose"
+          ID="CreatePoseStamped"
           reference_frame="left_grasp_link"
-          stamped_pose="{stamped_pose}"
+          pose_stamped="{pose_stamped}"
           position_xyz="0;-0.17;0"
           orientation_xyzw="0.0;0.0;0.0;1.0"
         />
         <Action
           ID="AddPoseStampedToVector"
-          input="{stamped_pose}"
+          input="{pose_stamped}"
           vector="{pose_stamped_vector}"
         />
         <Action
@@ -46,7 +46,7 @@
           marker_lifetime="0.000000"
           marker_name="pose2"
           marker_size="0.100000"
-          pose="{stamped_pose}"
+          pose="{pose_stamped}"
         />
         <Action
           ID="BreakpointSubscriber"


### PR DESCRIPTION
## Summary
same as: #19 , but for main branch
- Renames deprecated `CreateStampedPose` → `CreatePoseStamped` across all multi-tip and single-tip manipulation objectives
- Updates all blackboard key references from `{stamped_pose}` → `{pose_stamped}` and `init_stamped_pose` → `init_pose_stamped`
- Updates the subtree port name in `multi-tip_path_move_with_pose.xml` from `stamped_pose` to `pose_stamped`

This is the `main` branch equivalent of PR #19 (already merged into `for-example-ws-no-dups`).

## Files changed
- `multi-tip_path_move_up_bottle.xml`
- `multi-tip_path_move_push_bottle.xml`
- `multi-tip_path_re-orient_bottle.xml`
- `multi-tip_path_move_with_pose.xml`
- `multi-tip_path_re-orient_move_up_and_push.xml`
- `single-tip_path_admittance_move_push_bottle.xml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)