### PR TITLE
fix(ewellix_driver): point submodule to PickNik fork with warning fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/dependencies/ewellix_lift"]
 	path = src/dependencies/ewellix_lift
-	url = https://github.com/PickNikRobotics/ewellix_lift.git
+	url = https://github.com/clearpathrobotics/ewellix_lift.git
 [submodule "src/dependencies/moveit_studio_ur_pstop_manager"]
 	path = src/dependencies/moveit_studio_ur_pstop_manager
 	url = https://github.com/PickNikRobotics/moveit_studio_ur_pstop_manager.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "src/dependencies/ewellix_lift"]
 	path = src/dependencies/ewellix_lift
-	url = https://github.com/clearpathrobotics/ewellix_lift.git
+	url = https://github.com/PickNikRobotics/ewellix_lift.git
 [submodule "src/dependencies/moveit_studio_ur_pstop_manager"]
 	path = src/dependencies/moveit_studio_ur_pstop_manager
 	url = https://github.com/PickNikRobotics/moveit_studio_ur_pstop_manager.git


### PR DESCRIPTION
## Summary
Updates `ewellix_lift` submodule URL to `PickNikRobotics/ewellix_lift` and bumps SHA to the fix commit, resolving 10 compiler warnings that appear as `2 packages had stderr output` in the colcon build summary.

Upstream PR to clearpathrobotics: https://github.com/clearpathrobotics/ewellix_lift/pull/14  UPDATE: this merged, so now just updating SHA to point to the change, deleting fork. 

Once the upstream PR merges, the submodule URL can be reverted to `clearpathrobotics/ewellix_lift` and the SHA bumped to the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)