### PR TITLE
for main, fix(ewellix_driver): point submodule to PickNik fork with warning fixes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = git@github.com:PickNikRobotics/clearpath_controller_interface.git
 [submodule "src/dependencies/ewellix_lift"]
 	path = src/dependencies/ewellix_lift
-	url = https://github.com/clearpathrobotics/ewellix_lift.git
+	url = https://github.com/PickNikRobotics/ewellix_lift.git
 [submodule "src/dependencies/clearpath_common"]
 	path = src/dependencies/clearpath_common
 	url = git@github.com:clearpathrobotics/clearpath_common.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,7 @@
 	url = git@github.com:PickNikRobotics/clearpath_controller_interface.git
 [submodule "src/dependencies/ewellix_lift"]
 	path = src/dependencies/ewellix_lift
-	url = https://github.com/PickNikRobotics/ewellix_lift.git
+	url = https://github.com/clearpathrobotics/ewellix_lift.git
 [submodule "src/dependencies/clearpath_common"]
 	path = src/dependencies/clearpath_common
 	url = git@github.com:clearpathrobotics/clearpath_common.git


### PR DESCRIPTION
## Summary
Note this is for #25 , but targeted for main

Updates `ewellix_lift` submodule URL to `PickNikRobotics/ewellix_lift` and bumps SHA to the fix commit, resolving 10 compiler warnings that appear as `2 packages had stderr output` in the colcon build summary.

Fixes:
- `-Wcatch-value`: catch `serial::IOException` by const reference in `ewellix_serial.cpp`
- `-Wunused-parameter`: unused `previous_state` in lifecycle callbacks, unused `time`/`period` in `read`/`write`
- `-Wunused-private-field`: removed unused `in_motion_` from both headers

Upstream PR to clearpathrobotics: https://github.com/clearpathrobotics/ewellix_lift/pull/14
UPDATE: this merged, so now just updating SHA to point to the change, deleting fork. 

**Note:** Once the upstream PR merges, this should be followed up with a PR that reverts the submodule URL back to `clearpathrobotics/ewellix_lift` and bumps to the merged SHA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)