### PR TITLE
Refactor: Inline picknik_accessories camera bracket into phoebe_description

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/dependencies/picknik_accessories"]
-	path = src/dependencies/picknik_accessories
-	url = git@github.com:PickNikRobotics/picknik_accessories.git
 [submodule "src/dependencies/ros2_robotiq_gripper"]
 	path = src/dependencies/ros2_robotiq_gripper
 	url = git@github.com:PickNikRobotics/ros2_robotiq_gripper.git

--- a/src/phoebe_bridgeback_description/meshes/picknik_ur5_realsense_camera_adapter_rev2.dae
+++ b/src/phoebe_bridgeback_description/meshes/picknik_ur5_realsense_camera_adapter_rev2.dae
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4b7716daa331a01aa34a06d6d858d8508c635208fe05afce4a9e9a77192cc1b9
+size 66447

--- a/src/phoebe_bridgeback_description/meshes/picknik_ur5_realsense_camera_adapter_rev2_collision.stl
+++ b/src/phoebe_bridgeback_description/meshes/picknik_ur5_realsense_camera_adapter_rev2_collision.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9569607b57ac42b9df0f1859cfce821418265141a5cb1266bed3a356a2f5a05e
+size 9384

--- a/src/phoebe_bridgeback_description/xacro/ur5e.macro.xacro
+++ b/src/phoebe_bridgeback_description/xacro/ur5e.macro.xacro
@@ -501,14 +501,14 @@
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
           <mesh
-              filename="package://picknik_accessories/descriptions/brackets/ur_realsense_camera_adapter/picknik_ur5_realsense_camera_adapter_rev2.dae"/>
+              filename="package://phoebe_description/meshes/picknik_ur5_realsense_camera_adapter_rev2.dae"/>
         </geometry>
       </visual>
       <collision>
         <origin rpy="0 0 0" xyz="0 0 0"/>
         <geometry>
           <mesh
-              filename="package://picknik_accessories/descriptions/brackets/ur_realsense_camera_adapter/picknik_ur5_realsense_camera_adapter_rev2_collision.stl"/>
+              filename="package://phoebe_description/meshes/picknik_ur5_realsense_camera_adapter_rev2_collision.stl"/>
         </geometry>
       </collision>
     </link>

--- a/src/phoebe_hw/package.xml
+++ b/src/phoebe_hw/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>clearpath_sensors_description</exec_depend>
   <exec_depend>ewellix_description</exec_depend>
   <exec_depend>moveit_studio_ur_pstop_manager</exec_depend>
-  <exec_depend>picknik_accessories</exec_depend>
+  <exec_depend>phoebe_description</exec_depend>
   <exec_depend>robotiq_controllers</exec_depend>
   <exec_depend>robotiq_description</exec_depend>
   <exec_depend>robotiq_driver</exec_depend>

--- a/src/phoebe_sim/package.xml
+++ b/src/phoebe_sim/package.xml
@@ -23,7 +23,7 @@
   <exec_depend>clearpath_platform_description</exec_depend>
   <exec_depend>clearpath_sensors_description</exec_depend>
   <exec_depend>ewellix_description</exec_depend>
-  <exec_depend>picknik_accessories</exec_depend>
+  <exec_depend>phoebe_description</exec_depend>
   <exec_depend>robotiq_controllers</exec_depend>
   <exec_depend>robotiq_description</exec_depend>
   <exec_depend>ur_description</exec_depend>


### PR DESCRIPTION
## Summary

The only files this workspace used from the `picknik_accessories` submodule were two meshes for the UR realsense camera adapter bracket (`.dae` visual + `.stl` collision), referenced from `src/phoebe_bridgeback_description/xacro/ur5e.macro.xacro`. Inline them into `phoebe_description/meshes/` and drop the submodule so the workspace has one less external dep to keep in sync.

This also lets me archive picknik_accessories, as I want to merge it into moveit_pro_example_ws.

## Changes

- Copy `picknik_ur5_realsense_camera_adapter_rev2.dae` and `picknik_ur5_realsense_camera_adapter_rev2_collision.stl` into `src/phoebe_bridgeback_description/meshes/` (auto-tracked by Git LFS via existing `.gitattributes` rules for `*.dae` / `*.stl`).
- Repoint both `package://` URIs in `ur5e.macro.xacro:504` and `:511` from `picknik_accessories/descriptions/brackets/ur_realsense_camera_adapter/...` to `phoebe_description/meshes/...`.
- Remove `src/dependencies/picknik_accessories` submodule (`.gitmodules` entry + gitlink).
- Swap `<exec_depend>picknik_accessories</exec_depend>` for `<exec_depend>phoebe_description</exec_depend>` in `phoebe_sim/package.xml` and `phoebe_hw/package.xml`. `phoebe_description` was already used by these packages (via `$(find phoebe_description)/xacro/...` includes and `package://phoebe_description/meshes/...` references for other meshes) but never declared — this PR closes that latent gap.

## Verification

- `grep -r picknik_accessories src/` returns no matches (confirmed locally).
- The two meshes resolve to real LFS content (not pointers) on the original submodule; LFS upload succeeded on push.
- No build run yet — happy to add one if reviewers want it.