### PR TITLE
Fix: Vendor ewellix_description, drop Clearpath ewellix_lift submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "src/dependencies/ewellix_lift"]
-	path = src/dependencies/ewellix_lift
-	url = https://github.com/clearpathrobotics/ewellix_lift.git
 [submodule "src/dependencies/moveit_studio_ur_pstop_manager"]
 	path = src/dependencies/moveit_studio_ur_pstop_manager
 	url = https://github.com/PickNikRobotics/moveit_studio_ur_pstop_manager.git

--- a/README.md
+++ b/README.md
@@ -3,9 +3,8 @@
 3. `cd phoebe_ws`
 4. `git submodule update --init --recursive`
 5. `touch src/dependencies/clearpath_common/clearpath_generator_common/COLCON_IGNORE`
-6. `touch src/dependencies/ewellix_lift/ewellix_examples/COLCON_IGNORE`
-7. `pwd && moveit_pro configure`
-8. `moveit_pro build`
-9. `moveit_pro run -v -c phoebe_sim`
+6. `pwd && moveit_pro configure`
+7. `moveit_pro build`
+8. `moveit_pro run -v -c phoebe_sim`
 
 See the phoebe_hw package for details on running on hardware.

--- a/src/ewellix_description/CHANGELOG.rst
+++ b/src/ewellix_description/CHANGELOG.rst
@@ -1,0 +1,23 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package ewellix_description
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.1.0 (2025-01-15)
+------------------
+* Add launch parameter to modify lift description
+* Add friction and initialize lift extended
+* Add all meshes and description configs
+* Updated URDF and MoveIt for mimic joint
+* Add gazebo tag
+* Add gazebo tag
+* Use mimic joint
+* Pass origin instead of block
+* Reset package versions to 0.0.0
+* remove empty dependency
+* Add sample URDF
+* Increase tolerance
+* Fix position of mounting link
+* Add 2.25cm offset to upper tower
+* Initial add of Ewellix driver
+* Initial description package
+* Contributors: Luis Camero

--- a/src/ewellix_description/CMakeLists.txt
+++ b/src/ewellix_description/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.5)
+project(ewellix_description)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY config meshes urdf launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/src/ewellix_description/LICENSE
+++ b/src/ewellix_description/LICENSE
@@ -1,0 +1,28 @@
+BSD 3-Clause License
+
+Copyright (c) 2024, clearpathrobotics
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/ewellix_description/config/control/initial_positions.yaml
+++ b/src/ewellix_description/config/control/initial_positions.yaml
@@ -1,0 +1,2 @@
+initial_positions:
+  lift_lower_joint: 0.0

--- a/src/ewellix_description/config/control/joint_limits.yaml
+++ b/src/ewellix_description/config/control/joint_limits.yaml
@@ -1,0 +1,7 @@
+default_velocity_scaling_factor: 0.5
+default_acceleration_scaling_factor: 0.5
+
+joint_limits:
+  lift_lower_joint:
+    has_acceleration_limits: true
+    max_acceleration: 1.0

--- a/src/ewellix_description/config/control/jpc.yaml
+++ b/src/ewellix_description/config/control/jpc.yaml
@@ -1,0 +1,14 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 10  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    lift_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+lift_position_controller:
+  ros__parameters:
+    joints:
+      - lift_lower_joint

--- a/src/ewellix_description/config/control/jtc.yaml
+++ b/src/ewellix_description/config/control/jtc.yaml
@@ -1,0 +1,25 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 10  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    lift_joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+lift_joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - lift_lower_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 10.0
+    action_monitor_rate: 10.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.0
+      goal_time: 0.0

--- a/src/ewellix_description/config/tlt_x13.yaml
+++ b/src/ewellix_description/config/tlt_x13.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/short/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.3250
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/short/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.4850
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.1720
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/short/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 0.6350
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.3150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x14.yaml
+++ b/src/ewellix_description/config/tlt_x14.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/short/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.3750
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/short/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.5850
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.2220
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/short/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 0.7850
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.4150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x15.yaml
+++ b/src/ewellix_description/config/tlt_x15.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/short/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.4250
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/short/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.6850
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.2720
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.25
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/short/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 0.9350
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.5150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.25
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x16.yaml
+++ b/src/ewellix_description/config/tlt_x16.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/short/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.4750
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/short/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.7850
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.3220
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/short/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 1.0850
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.6150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x17.yaml
+++ b/src/ewellix_description/config/tlt_x17.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/short/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.5250
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/short/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.8850
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.3720
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/short/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 1.2350
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.7150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 1000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x23.yaml
+++ b/src/ewellix_description/config/tlt_x23.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/long/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.3950
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/long/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.5550
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.1720
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt300/long/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 0.7050
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.3150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x24.yaml
+++ b/src/ewellix_description/config/tlt_x24.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/long/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.4450
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/long/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.6550
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.2220
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt400/long/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 0.8550
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.4150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x25.yaml
+++ b/src/ewellix_description/config/tlt_x25.yaml
@@ -1,0 +1,76 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/long/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.4951
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0151
+  mass: 10.0
+  offset: 0.0
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/long/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.7551
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.2721
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000.0
+      lower: 0.0
+      upper: 0.25
+      velocity: 0.025
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt500/long/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 1.0051
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.5151
+  mass: 10.0
+  offset: 0.0225
+  joint:
+    limit:
+      effort: 2000.0
+      lower: 0.0
+      upper: 0.25
+      velocity: 0.025
+
+

--- a/src/ewellix_description/config/tlt_x26.yaml
+++ b/src/ewellix_description/config/tlt_x26.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/long/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.5450
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/long/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.8550
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.3220
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt600/long/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 1.1550
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.6150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/config/tlt_x27.yaml
+++ b/src/ewellix_description/config/tlt_x27.yaml
@@ -1,0 +1,80 @@
+plate:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/plate.stl
+  max:
+    x: 0.1000
+    y: 0.1100
+    z: 0.0150
+  min:
+    x: -0.1000
+    y: -0.1100
+    z: -0.0000
+  mass: 1.0
+
+base:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/long/base.stl
+  max:
+    x: 0.0827
+    y: 0.0827
+    z: 0.5950
+  min:
+    x: -0.0827
+    y: -0.0827
+    z: 0.0150
+  mass: 10.0
+  offset: 0.015
+
+lower:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/long/lower.stl
+  max:
+    x: 0.0742
+    y: 0.0742
+    z: 0.9550
+  min:
+    x: -0.0742
+    y: -0.0742
+    z: 0.3720
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+upper:
+  material:
+    name: "LightGrey"
+    color: "0.7 0.7 0.7 1.0"
+  mesh: tlt700/long/upper.stl
+  max:
+    x: 0.0645
+    y: 0.0645
+    z: 1.3050
+  min:
+    x: -0.0645
+    y: -0.0645
+    z: 0.7150
+  mass: 10.0
+  offset: 0.0
+  joint:
+    limit:
+      effort: 2000
+      lower: 0.0
+      upper: 0.15
+      velocity: 0.088
+    axis:
+      xyz: "0 0 1"
+
+

--- a/src/ewellix_description/launch/description.launch.py
+++ b/src/ewellix_description/launch/description.launch.py
@@ -1,0 +1,132 @@
+# Software License Agreement (BSD)
+#
+# @author    Luis Camero <lcamero@clearpathrobotics.com>
+# @copyright (c) 2025, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors
+#   may be used to endorse or promote products derived from this software
+#   without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# Redistribution and use in source and binary forms, with or without
+# modification, is not permitted without the express permission
+# of Clearpath Robotics.
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import (Command, FindExecutable,
+                                  PathJoinSubstitution, LaunchConfiguration)
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+from launch_ros.substitutions import FindPackageShare
+
+
+def generate_launch_description():
+    package = FindPackageShare('ewellix_description')
+    # Launch Configurations
+    robot_description_command = LaunchConfiguration('robot_description_command')
+
+    use_sim_time = LaunchConfiguration('use_sim_time')
+    arg_use_sim_time = DeclareLaunchArgument(
+        'use_sim_time',
+        choices=['true', 'false'],
+        default_value='false',
+        description='Use simulation time'
+    )
+
+    control_config = LaunchConfiguration('control_config')
+    arg_control_config = DeclareLaunchArgument(
+        'control_config',
+        default_value=PathJoinSubstitution([
+            package,
+            'config',
+            'control',
+            'jtc.yaml'
+        ]),
+        description='ROS 2 controller file to pass to Gazebo.'
+    )
+
+    lift_parameters = LaunchConfiguration('lift_parameters')
+    arg_lift_parameters = DeclareLaunchArgument(
+        'lift_parameters',
+        default_value=PathJoinSubstitution([
+            package,
+            'config',
+            'tlt_x25.yaml'
+        ]),
+        description='Lift description configuration file.'
+    )
+
+    # Paths
+    urdf = PathJoinSubstitution([
+        package,
+        'urdf',
+        'ewellix_lift.urdf.xacro'
+    ])
+
+    # Get URDF via xacro
+    arg_robot_description_command = DeclareLaunchArgument(
+        'robot_description_command',
+        default_value=[
+            PathJoinSubstitution([FindExecutable(name='xacro')]),
+            ' ',
+            urdf,
+            ' ',
+            'sim_ignition:=',
+            use_sim_time,
+            ' ',
+            'use_fake_hardware:=',
+            'false',
+            ' ',
+            'generate_ros2_control_tag:=',
+            'true',
+            ' ',
+            'gazebo_controllers:=',
+            control_config,
+            ' ',
+            'parameters_file:=',
+            lift_parameters
+        ]
+    )
+
+    robot_description_content = ParameterValue(
+        Command(robot_description_command),
+        value_type=str
+    )
+
+    # Lift State Publisher
+    lift_state_publisher = Node(
+        package='robot_state_publisher',
+        executable='robot_state_publisher',
+        parameters=[{
+            'robot_description': robot_description_content,
+            'use_sim_time': use_sim_time,
+        }]
+    )
+
+    ld = LaunchDescription()
+    # Args
+    ld.add_action(arg_use_sim_time)
+    ld.add_action(arg_lift_parameters)
+    ld.add_action(arg_control_config)
+    ld.add_action(arg_robot_description_command)
+    # Nodes
+    ld.add_action(lift_state_publisher)
+    return ld

--- a/src/ewellix_description/meshes/tlt300/long/base.stl
+++ b/src/ewellix_description/meshes/tlt300/long/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:db9c17b142306ca76a8f8eb1f6f03cde97e910a31e3b8d9d5a4f6f05f459e420
+size 164684

--- a/src/ewellix_description/meshes/tlt300/long/full.stl
+++ b/src/ewellix_description/meshes/tlt300/long/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:36c407e1cbce2201f640b10cb8b7fc87ef5403a49a794751da2bc125e2ece577
+size 475184

--- a/src/ewellix_description/meshes/tlt300/long/lower.stl
+++ b/src/ewellix_description/meshes/tlt300/long/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dfd4eb929bbc0b813a57884676897efb05ab4c9c45560b466fd94dcfb2aa0388
+size 128884

--- a/src/ewellix_description/meshes/tlt300/long/upper.stl
+++ b/src/ewellix_description/meshes/tlt300/long/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34361de606a1531465a431dda5fd84b4de47b6b7a3465c23e33d621716be9254
+size 44184

--- a/src/ewellix_description/meshes/tlt300/plate.stl
+++ b/src/ewellix_description/meshes/tlt300/plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b236a009249bc2e0ceccecab2113b75cf4af1d0a881e4b9e45ca33062a1b563
+size 114084

--- a/src/ewellix_description/meshes/tlt300/short/base.stl
+++ b/src/ewellix_description/meshes/tlt300/short/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d56bd82067df2580decdc49cf068ff60aa903b2da56269abcb00fca32cf5ae83
+size 164684

--- a/src/ewellix_description/meshes/tlt300/short/full.stl
+++ b/src/ewellix_description/meshes/tlt300/short/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5a1f262eacad70a9293f8fd69f2443014941d7785d8b28e8876e1f1b9d705f5d
+size 475184

--- a/src/ewellix_description/meshes/tlt300/short/lower.stl
+++ b/src/ewellix_description/meshes/tlt300/short/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e17f00b2ec53fcd005d2ddc07397e9e1e05031f640022c99eb0d03b2aca6c4b
+size 128884

--- a/src/ewellix_description/meshes/tlt300/short/upper.stl
+++ b/src/ewellix_description/meshes/tlt300/short/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee5008b9ce1801d5aa2a26472110508de642cedcadf10f7ae8cb0e47d837dde2
+size 44184

--- a/src/ewellix_description/meshes/tlt400/long/base.stl
+++ b/src/ewellix_description/meshes/tlt400/long/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c6469af2a842692a7588f3dec2abb83ccc43deec4e8703e669520a7f95750f8b
+size 164684

--- a/src/ewellix_description/meshes/tlt400/long/full.stl
+++ b/src/ewellix_description/meshes/tlt400/long/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:53ec2bb4a2ea92b4d3c819902d9617f0fc6d7b1d807e77fb8af2b00afa7cc459
+size 475184

--- a/src/ewellix_description/meshes/tlt400/long/lower.stl
+++ b/src/ewellix_description/meshes/tlt400/long/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:843a5aaae97e9b18d2e9cc5a55e5d8831aa722ecdfcbcfc635241eba00b93fde
+size 128884

--- a/src/ewellix_description/meshes/tlt400/long/upper.stl
+++ b/src/ewellix_description/meshes/tlt400/long/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:852454abecc06bc2861ec5da4fdacfc8a67c8b88cc3b9e194b11d05f4c53ee79
+size 44184

--- a/src/ewellix_description/meshes/tlt400/plate.stl
+++ b/src/ewellix_description/meshes/tlt400/plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b236a009249bc2e0ceccecab2113b75cf4af1d0a881e4b9e45ca33062a1b563
+size 114084

--- a/src/ewellix_description/meshes/tlt400/short/base.stl
+++ b/src/ewellix_description/meshes/tlt400/short/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1fd0433c4b2cccb5d1bdf7b96e9f57a7c78ee362fb122167dcc9bb5940862153
+size 164684

--- a/src/ewellix_description/meshes/tlt400/short/full.stl
+++ b/src/ewellix_description/meshes/tlt400/short/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:31dc70585a45d68c8257fd32a610175b23cadcb3d9c05afb67d7d231eba815a1
+size 475184

--- a/src/ewellix_description/meshes/tlt400/short/lower.stl
+++ b/src/ewellix_description/meshes/tlt400/short/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e5d53bca667a171d27d9eadc63189fd6f13fe9fc989579e961c3b5e26e287075
+size 128884

--- a/src/ewellix_description/meshes/tlt400/short/upper.stl
+++ b/src/ewellix_description/meshes/tlt400/short/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:373611c9b5b2cc4a24757aca0ded2b695297851190bc3384692e582e469dba5f
+size 44184

--- a/src/ewellix_description/meshes/tlt500/long/base.stl
+++ b/src/ewellix_description/meshes/tlt500/long/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:032d12123df60e5313d53961b49244ab7d53ea37cac3e3510a57dd0923742475
+size 164684

--- a/src/ewellix_description/meshes/tlt500/long/full.stl
+++ b/src/ewellix_description/meshes/tlt500/long/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c80cb1cf43f0b1415fde2106c08070276fbbeafad622d40e374c98892599cd5
+size 475184

--- a/src/ewellix_description/meshes/tlt500/long/lower.stl
+++ b/src/ewellix_description/meshes/tlt500/long/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:063507f941e83b981d02aca9794c5795df94a16a7650d04fc0620a0c63610532
+size 128884

--- a/src/ewellix_description/meshes/tlt500/long/upper.stl
+++ b/src/ewellix_description/meshes/tlt500/long/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0af87e6b081f96a2840e4b49eb0746402dafb5a0fd9a16629c65f2d955ebcd6
+size 44184

--- a/src/ewellix_description/meshes/tlt500/plate.stl
+++ b/src/ewellix_description/meshes/tlt500/plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b236a009249bc2e0ceccecab2113b75cf4af1d0a881e4b9e45ca33062a1b563
+size 114084

--- a/src/ewellix_description/meshes/tlt500/short/base.stl
+++ b/src/ewellix_description/meshes/tlt500/short/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7b1b4acbc98817e191741aed1fe4b1bdf9e849a3848bd91f23cbad716e6d5447
+size 164684

--- a/src/ewellix_description/meshes/tlt500/short/full.stl
+++ b/src/ewellix_description/meshes/tlt500/short/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fbfd3aed4b38e42c7662458e80010d9b79b0c39379c42c6096a29c1294b83e0c
+size 475184

--- a/src/ewellix_description/meshes/tlt500/short/lower.stl
+++ b/src/ewellix_description/meshes/tlt500/short/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:99fead53c3d58fa36b79c2af3d83349ac6f73520f6eaeb224d43de5bbb9e78da
+size 128884

--- a/src/ewellix_description/meshes/tlt500/short/upper.stl
+++ b/src/ewellix_description/meshes/tlt500/short/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5f5bb3f04ecf66d1863b3daa235b11c91c4bd5c6a83c861340929fc96d4e337a
+size 44184

--- a/src/ewellix_description/meshes/tlt600/long/base.stl
+++ b/src/ewellix_description/meshes/tlt600/long/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f47e1c9c88561f3f84306db6dd0e679c43a10413e70e4c1d2eab06aebf3dd86
+size 164684

--- a/src/ewellix_description/meshes/tlt600/long/full.stl
+++ b/src/ewellix_description/meshes/tlt600/long/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b71190ccec43b534ed7d99ff83a96173d712b6a68a1b4439049d599d6eb53767
+size 475184

--- a/src/ewellix_description/meshes/tlt600/long/lower.stl
+++ b/src/ewellix_description/meshes/tlt600/long/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:caae23031171a6bc2e9daa49e6cfd84d33d953dec788f36eba62760d94848e09
+size 128884

--- a/src/ewellix_description/meshes/tlt600/long/upper.stl
+++ b/src/ewellix_description/meshes/tlt600/long/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7877e0b209a5b24a3e1780d613cfd9c76676380a8825191ed05bea963df2c0c7
+size 44184

--- a/src/ewellix_description/meshes/tlt600/plate.stl
+++ b/src/ewellix_description/meshes/tlt600/plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b236a009249bc2e0ceccecab2113b75cf4af1d0a881e4b9e45ca33062a1b563
+size 114084

--- a/src/ewellix_description/meshes/tlt600/short/base.stl
+++ b/src/ewellix_description/meshes/tlt600/short/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d819dfb9a96560de91c6f2a8632f818b6a042dfa443ae59b26cf5824cbaf165b
+size 164684

--- a/src/ewellix_description/meshes/tlt600/short/full.stl
+++ b/src/ewellix_description/meshes/tlt600/short/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8329f56dc56a32edd1bb471462e50687ae099695bd939fb3df022cbd46200211
+size 475184

--- a/src/ewellix_description/meshes/tlt600/short/lower.stl
+++ b/src/ewellix_description/meshes/tlt600/short/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7d6f18be74aa742a946bbda934be2a2f13f6136e79859d77bbd8c1b4b6b28e2d
+size 128884

--- a/src/ewellix_description/meshes/tlt600/short/upper.stl
+++ b/src/ewellix_description/meshes/tlt600/short/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d49242bd2e9d9cad574b64781a6f70984e701cd839f6be214a9e947a01cf2742
+size 44184

--- a/src/ewellix_description/meshes/tlt700/long/base.stl
+++ b/src/ewellix_description/meshes/tlt700/long/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e38faf1b5c4945b7064a42d4b6f060e99f15453a25c655e8c6ce88672d2ff74
+size 164684

--- a/src/ewellix_description/meshes/tlt700/long/full.stl
+++ b/src/ewellix_description/meshes/tlt700/long/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63878e0689623092fcdb25163e3225adca8b42f67bca3e0453d812647ce5b200
+size 475184

--- a/src/ewellix_description/meshes/tlt700/long/lower.stl
+++ b/src/ewellix_description/meshes/tlt700/long/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b05f644878dff89eacf84a118cdc3c1077407b496da63750e2430d9011c651c8
+size 128884

--- a/src/ewellix_description/meshes/tlt700/long/upper.stl
+++ b/src/ewellix_description/meshes/tlt700/long/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dbb2e8e89dc1f1eaa2a1076c260c5720123c90b7dcd89b26717a3b5a0afcd8a0
+size 44184

--- a/src/ewellix_description/meshes/tlt700/plate.stl
+++ b/src/ewellix_description/meshes/tlt700/plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9b236a009249bc2e0ceccecab2113b75cf4af1d0a881e4b9e45ca33062a1b563
+size 114084

--- a/src/ewellix_description/meshes/tlt700/short/base.stl
+++ b/src/ewellix_description/meshes/tlt700/short/base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:61fad4080eee087c2e51b4fafc7b998718373c895be1debe00d5e8c5afd783c5
+size 164684

--- a/src/ewellix_description/meshes/tlt700/short/full.stl
+++ b/src/ewellix_description/meshes/tlt700/short/full.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:57d91d1ce08588468fbde357b8d2ea173543ae40ca4dea2d7f63d05dad70b8e9
+size 475184

--- a/src/ewellix_description/meshes/tlt700/short/lower.stl
+++ b/src/ewellix_description/meshes/tlt700/short/lower.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:070757d0f72108d0e2daef87a30179b35cc8f8bc6034ab129b677bcff5aa1694
+size 128884

--- a/src/ewellix_description/meshes/tlt700/short/upper.stl
+++ b/src/ewellix_description/meshes/tlt700/short/upper.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a0d1cce33aca5ed9739eb70c0e4afae99d541e633048cbc7cc156750dbf647a
+size 44184

--- a/src/ewellix_description/package.xml
+++ b/src/ewellix_description/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>ewellix_description</name>
+  <version>0.1.0</version>
+  <description>Clearpath's description package for Ewellix TLT lifting columns</description>
+
+  <author email="lcamero@clearpathrobotics.com">Luis Camero</author>
+  <maintainer email="lcamero@clearpathrobotics.com">Luis Camero</maintainer>
+
+  <license>BSD</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/ewellix_description/urdf/ewellix_lift.urdf.xacro
+++ b/src/ewellix_description/urdf/ewellix_lift.urdf.xacro
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<robot name="ewellix_lift" xmlns:xacro="http://www.ros.org/wiki/xacro">
+  <!-- Include Macro -->
+  <xacro:include filename="$(find ewellix_description)/urdf/ewellix_macro.xacro"/>
+
+  <!-- Arguments -->
+  <xacro:arg name="type" default="tlt_x25"/>
+  <xacro:arg name="tf_prefix" default="lift_"/>
+  <xacro:arg name="add_plate" default="true"/>
+  <xacro:arg name="initial_positions" default="${dict(lower=0.0, upper=0.0)}"/>
+  <xacro:arg name="parameters_file" default="$(find ewellix_description)/config/$(arg type).yaml"/>
+  <xacro:arg name="generate_ros2_control_tag" default="true"/>
+  <xacro:arg name="gazebo_controllers" default="$(find ewellix_description)/config/control/jtc.yaml"/>
+  <xacro:arg name="use_fake_hardware" default="false"/>
+  <xacro:arg name="sim_ignition" default="false"/>
+  <xacro:arg name="port" default="/dev/ttyUSB0"/>
+  <xacro:arg name="baud" default="38400"/>
+  <xacro:arg name="timeout" default="1000"/>
+  <xacro:arg name="conversion" default="3225"/>
+  <xacro:arg name="rated_effort" default="2000"/>
+  <xacro:arg name="tolerance" default="0.005"/>
+
+  <!-- Base Link -->
+  <link name="base_link"/>
+
+  <!-- Ewellix Description -->
+  <xacro:ewellix_lift
+    parent="base_link"
+    tf_prefix="$(arg tf_prefix)"
+    add_plate="$(arg add_plate)"
+    parameters_file="$(arg parameters_file)"
+    generate_ros2_control_tag="$(arg generate_ros2_control_tag)"
+    use_fake_hardware="$(arg use_fake_hardware)"
+    sim_ignition="$(arg sim_ignition)"
+    port="$(arg port)"
+    baud="$(arg baud)"
+    timeout="$(arg timeout)"
+    conversion="$(arg conversion)"
+    rated_effort="$(arg rated_effort)"
+    tolerance="$(arg tolerance)"
+    >
+    <origin xyz="0 0 0" rpy="0 0 0"/>
+  </xacro:ewellix_lift>
+
+  <!-- Gazebo -->
+  <xacro:if value="$(arg sim_ignition)">
+    <gazebo>
+      <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+        <parameters>$(arg gazebo_controllers)</parameters>
+      </plugin>
+    </gazebo>
+
+    <gazebo>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>true</publish_link_pose>
+        <publish_nested_model_pose>true</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <update_frequency>50</update_frequency>
+      </plugin>
+    </gazebo>
+  </xacro:if>
+</robot>

--- a/src/ewellix_description/urdf/ewellix_macro.xacro
+++ b/src/ewellix_description/urdf/ewellix_macro.xacro
@@ -1,0 +1,242 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro">
+
+  <xacro:macro name="ewellix_link" params="
+    name
+    mesh
+    maximum
+    minimum
+    mass
+    *material">
+    <!-- Parameters -->
+    <xacro:property name="size"
+      value="${dict([
+      ('x', fabs(maximum.x-minimum.x)),
+      ('y', fabs(maximum.y-minimum.y)),
+      ('z', fabs(maximum.z-minimum.z))
+      ])}"/>
+
+    <xacro:property name="thickness" value="0.001"/>
+
+    <xacro:property
+      name="ixx"
+      value="${mass/12 * (size['y']**2 + size['z']**2)}"/>
+    <xacro:property
+      name="iyy"
+      value="${mass/12 * (size['x']**2 + size['z']**2)}"/>
+    <xacro:property
+      name="izz"
+      value="${mass/12 * (size['x']**2 + size['y']**2)}"/>
+
+    <!-- Link -->
+    <link name="${name}">
+      <visual>
+        <origin xyz="0.0 0.0 ${-minimum.z}" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <mesh filename="${mesh}"/>
+        </geometry>
+        <xacro:insert_block name="material"/>
+      </visual>
+
+      <collision>
+        <origin xyz="0.0 0.0 ${size['z']/2}" rpy="0.0 0.0 0.0"/>
+        <geometry>
+          <box size="${size['x']} ${size['y']} ${size['z']}"/>
+        </geometry>
+        <xacro:insert_block name="material"/>
+      </collision>
+
+      <inertial>
+        <mass value="${mass}"/>
+        <origin xyz="0.0 0.0 ${size['z']/2}" rpy="0.0 0.0 0.0"/>
+        <inertia
+          ixx="${ixx}" ixy="0.0" ixz="0.0"
+          iyy="${iyy}" iyz="0.0"
+          izz="${izz}"/>
+      </inertial>
+    </link>
+  </xacro:macro>
+
+  <xacro:macro name="ewellix_prismatic_link" params="
+    name
+    mesh
+    maximum
+    minimum
+    mass
+    *material">
+    <!-- Link -->
+    <!-- Fixed Joint -->
+  </xacro:macro>
+
+  <!-- Common Macro for Ewellix Lift -->
+  <xacro:macro name="ewellix_lift" params="
+    parent
+    tf_prefix
+    add_plate:=true
+    initial_positions:=${dict(upper=0.0, lower=0.0)}
+    parameters_file:='$(find ewellix_description)/config/tlt_x25.yaml'
+    generate_ros2_control_tag:=false
+    use_fake_hardware:=false
+    sim_ignition:=false
+    port='/dev/ttyUSB0'
+    baud=38400
+    timeout=1000
+    conversion=3225
+    rated_effort=2000
+    tolerance=0.005
+    *origin">
+    <!-- Parameters -->
+    <xacro:property name="parameters" value="${xacro.load_yaml(parameters_file)}"/>
+
+    <!-- Plate -->
+    <xacro:if value="${add_plate}">
+      <xacro:ewellix_link
+        name="${tf_prefix}plate_link"
+        mesh="package://ewellix_description/meshes/${parameters.plate.mesh}"
+        maximum="${parameters.plate.max}"
+        minimum="${parameters.plate.min}"
+        mass="${parameters.plate.mass}">
+        <material name="${parameters.plate.material.name}">
+        <color rgba="${parameters.plate.material.color}"/>
+        </material>
+      </xacro:ewellix_link>
+
+      <joint name="${tf_prefix}plate_joint" type="fixed">
+        <child link="${tf_prefix}plate_link"/>
+        <parent link="${parent}"/>
+        <xacro:insert_block name="origin"/>
+      </joint>
+
+      <joint name="${tf_prefix}base_joint" type="fixed">
+        <child link="${tf_prefix}base_link"/>
+        <parent link="${tf_prefix}plate_link"/>
+        <origin xyz="0.0 0.0 ${fabs(parameters.plate.max.z - parameters.plate.min.z) + parameters.base.offset}" rpy="0.0 0.0 0.0"/>
+      </joint>
+    </xacro:if>
+    <xacro:unless value="${add_plate}">
+      <joint name="${tf_prefix}base_joint" type="fixed">
+        <child link="${tf_prefix}base_link"/>
+        <parent link="${parent}"/>
+        <xacro:insert_block name="origin"/>
+      </joint>
+    </xacro:unless>
+
+    <!-- Base -->
+    <xacro:ewellix_link
+      name="${tf_prefix}base_link"
+      mesh="package://ewellix_description/meshes/${parameters.base.mesh}"
+      maximum="${parameters.base.max}"
+      minimum="${parameters.base.min}"
+      mass="${parameters.base.mass}">
+      <material name="${parameters.base.material.name}">
+      <color rgba="${parameters.base.material.color}"/>
+      </material>
+    </xacro:ewellix_link>
+
+    <!-- Lower Tower -->
+    <xacro:ewellix_link
+      name="${tf_prefix}lower_link"
+      mesh="package://ewellix_description/meshes/${parameters.lower.mesh}"
+      maximum="${parameters.lower.max}"
+      minimum="${parameters.lower.min}"
+      mass="${parameters.lower.mass}">
+      <material name="${parameters.lower.material.name}">
+      <color rgba="${parameters.lower.material.color}"/>
+      </material>
+    </xacro:ewellix_link>
+
+    <joint name="${tf_prefix}lower_joint" type="prismatic">
+      <child link="${tf_prefix}lower_link"/>
+      <parent link="${tf_prefix}base_link"/>
+      <origin
+        xyz="0.0 0.0 ${parameters.lower.offset}"
+        rpy="0.0 0.0 0.0"/>
+      <limit
+        effort="${parameters.lower.joint.limit.effort}"
+        lower="${parameters.lower.joint.limit.lower}"
+        upper="${parameters.lower.joint.limit.upper}"
+        velocity="${parameters.lower.joint.limit.velocity}"/>
+      <axis xyz="0 0 1"/>
+      <dynamics friction="0.01" damping="0.01"/>
+    </joint>
+
+    <!-- Upper Tower -->
+    <xacro:ewellix_link
+      name="${tf_prefix}upper_link"
+      mesh="package://ewellix_description/meshes/${parameters.upper.mesh}"
+      maximum="${parameters.upper.max}"
+      minimum="${parameters.upper.min}"
+      mass="${parameters.upper.mass}">
+      <material name="${parameters.upper.material.name}">
+      <color rgba="${parameters.upper.material.color}"/>
+      </material>
+    </xacro:ewellix_link>
+
+    <joint name="${tf_prefix}upper_joint" type="prismatic">
+      <child link="${tf_prefix}upper_link"/>
+      <parent link="${tf_prefix}lower_link"/>
+      <origin
+        xyz="0.0 0.0 ${parameters.upper.offset}"
+        rpy="0.0 0.0 0.0"/>
+      <axis xyz="0 0 1"/>
+      <limit
+        effort="${parameters.upper.joint.limit.effort}"
+        lower="${parameters.upper.joint.limit.lower}"
+        upper="${parameters.upper.joint.limit.upper}"
+        velocity="${parameters.upper.joint.limit.velocity}"/>
+      <dynamics friction="0.01" damping="0.01"/>
+      <mimic joint="${tf_prefix}lower_joint"/>
+    </joint>
+
+    <!-- Mount -->
+    <link name="${tf_prefix}mount"/>
+
+    <joint name="${tf_prefix}mount_joint" type="fixed">
+      <child link="${tf_prefix}mount"/>
+      <parent link="${tf_prefix}upper_link"/>
+      <origin
+        xyz="0.0 0.0 ${fabs(parameters.upper.max.z - parameters.upper.min.z)}"
+        rpy="0.0 0.0 0.0"/>
+    </joint>
+
+    <!-- ROS 2 Controls -->
+    <xacro:if value="${generate_ros2_control_tag}">
+      <ros2_control name="${tf_prefix}hardware" type="system">
+        <hardware>
+          <xacro:if value="${sim_ignition}">
+            <plugin>ign_ros2_control/IgnitionSystem</plugin>
+          </xacro:if>
+          <xacro:if value="${use_fake_hardware}">
+            <plugin>mock_components/GenericSystem</plugin>
+            <param name="state_following_offset">0.0</param>
+            <param name="calculate_dynamics">true</param>
+          </xacro:if>
+          <xacro:unless value="${use_fake_hardware or sim_ignition}">
+            <plugin>ewellix_driver/EwellixHardwareInterface</plugin>
+            <param name="port">${port}</param>
+            <param name="baud">${baud}</param>
+            <param name="timeout">${timeout}</param>
+            <param name="conversion">${conversion}</param>
+            <param name="rated_effort">${rated_effort}</param>
+            <param name="tolerance">${tolerance}</param>
+          </xacro:unless>
+        </hardware>
+        <joint name="${tf_prefix}lower_joint">
+          <command_interface name="position"/>
+          <state_interface name="position">
+            <param name="initial_value">${parameters.lower.joint.limit.upper}</param>
+          </state_interface>
+          <state_interface name="velocity"/>
+          <state_interface name="effort"/>
+        </joint>
+        <xacro:if value="${sim_ignition or use_fake_hardware}">
+          <joint name="${tf_prefix}upper_joint">
+            <param name="mimic">${tf_prefix}lower_joint</param>
+            <param name="multiplier">1</param>
+          </joint>
+        </xacro:if>
+      </ros2_control>
+    </xacro:if>
+
+  </xacro:macro>
+</robot>


### PR DESCRIPTION
Fixes the example_ws Jazzy rosdep break (PickNikRobotics/moveit_pro#19620): `ewellix_examples` hardcodes `ign_ros2_control` (renamed `gz_ros2_control` on Jazzy).

`phoebe_sim` only needs `ewellix_description` from the Clearpath submodule — verified: it's the sole ewellix entry in `colcon list --packages-up-to phoebe_sim`, and the build is green with the other four `COLCON_IGNORE`'d.

- Drop the `ewellix_lift` submodule (sim-only branch; `phoebe_hw` already gone here).
- Vendor `ewellix_description` at `src/` — not `src/dependencies/`, which is reserved for submodules (a real folder there causes git conflicts on update). Package name kept so `package://` + `exec_depend` resolve.
- Remove the stale `ewellix_examples` `COLCON_IGNORE` README step.

The large file count is the copied-in `ewellix_description` package (~45 `.stl` meshes plus config/urdf/launch); the only hand edits are `.gitmodules`, the submodule removal, and the README.

`main` keeps the submodule + `phoebe_hw`, so hardware still builds standalone.

## Follow-up after this merges

- [ ] Bump `phoebe_ws` submodule pointer in `moveit_pro_example_ws` to this branch's merged tip.
- [ ] Verify **Jazzy** rosdep + build of `lunar_sim`/`hangar_sim` in example_ws (the end-to-end fix confirmation).
- [ ] Comment + close PickNikRobotics/moveit_pro#19620.
- [ ] (Optional) Drop now-redundant `ros-*-ewellix-description` from phoebe_ws Dockerfile apt line.

## Release notes

None.