### PR TITLE
Remove unused L2G ONNX model

### DIFF
--- a/src/phoebe_sim/models/l2g.onnx
+++ b/src/phoebe_sim/models/l2g.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc1fd4a7cf185225ba29940da16cf052cc9801a4883aecffd82845627e0965b5
-size 15618125


### PR DESCRIPTION
[written by AI]

## Problem

`src/phoebe_sim/models/l2g.onnx` is an orphaned L2G weight — no phoebe_sim objective references `GetGraspPoseFromPointCloud` or `l2g.onnx` (grep-verified across objectives, config, launch, CMake).

L2G's upstream (https://github.com/antoalli/L2G) ships **no license**, so redistributing this ONNX under phoebe_sim's license has no grant behind it. Removing the unused copy is a zero-risk step of the ML-weight licensing cleanup (PickNikRobotics/moveit_pro#20353, epic PickNikRobotics/moveit_pro#20347).

## Change

`git rm src/phoebe_sim/models/l2g.onnx` only. `models/` still ships `decoder.onnx` and `sam2_hiera_large_encoder.onnx`, so the `install(DIRECTORY … models …)` rule in `CMakeLists.txt` is unchanged.

## Release notes

None