### PR TITLE
chore(phoebe_sim): remove unused L2G ONNX model

### DIFF
--- a/src/phoebe_sim/CMakeLists.txt
+++ b/src/phoebe_sim/CMakeLists.txt
@@ -9,7 +9,6 @@ install(
     description
     launch
     meshes
-    models
     objectives
     rviz
     waypoints

--- a/src/phoebe_sim/models/l2g.onnx
+++ b/src/phoebe_sim/models/l2g.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fc1fd4a7cf185225ba29940da16cf052cc9801a4883aecffd82845627e0965b5
-size 15618125


### PR DESCRIPTION
[written by AI]

## Problem

`src/phoebe_sim/models/l2g.onnx` is an orphaned L2G weight on this branch — no phoebe_sim objective references `GetGraspPoseFromPointCloud` or `l2g.onnx` (grep-verified). On `for-example-ws-no-dups` it is the only file in `models/`.

L2G's upstream (https://github.com/antoalli/L2G) ships **no license**, so redistributing this ONNX has no grant behind it. Part of the ML-weight licensing cleanup (PickNikRobotics/moveit_pro#20353, epic PickNikRobotics/moveit_pro#20347).

Targets `for-example-ws-no-dups` because that is the branch `moveit_pro_example_ws` consumes via submodule (not `main`). A follow-up example_ws PR will bump the phoebe gitlink to include this.

## Change

- `git rm src/phoebe_sim/models/l2g.onnx`
- Drop `models` from the `install(DIRECTORY …)` list in `CMakeLists.txt` — it was the only file in that dir, so leaving the rule would fail the build on the now-missing dir.

## Release notes

None
