### PR TITLE
Migrate phoebe_sim Objectives off deprecated PlanCartesianPath timing ports (no-dups)

### DIFF
--- a/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
@@ -47,7 +47,6 @@
       <Control ID="Fallback">
         <Action
           ID="PlanCartesianPath"
-          acceleration_scale_factor="1.000000"
           blending_radius="0.020000"
           debug_solution="{debug_solution}"
           ik_cartesian_space_density="0.010000"
@@ -56,8 +55,7 @@
           path="{pose_stamped_vector}"
           position_only="false"
           tip_links="left_grasp_link;right_grasp_link"
-          trajectory_sampling_rate="100"
-          velocity_scale_factor="1.000000"
+          trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"
           tip_offset="0;0;0;0;0;0"
           planning_group_name="arms_only"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
@@ -47,7 +47,6 @@
       <Control ID="Fallback">
         <Action
           ID="PlanCartesianPath"
-          acceleration_scale_factor="1.000000"
           blending_radius="0.020000"
           debug_solution="{debug_solution}"
           ik_cartesian_space_density="0.010000"
@@ -56,8 +55,7 @@
           path="{pose_stamped_vector}"
           position_only="false"
           tip_links="left_grasp_link;right_grasp_link"
-          trajectory_sampling_rate="100"
-          velocity_scale_factor="1.000000"
+          trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"
           tip_offset="0;0;0;0;0;0"
           planning_group_name="arms_only"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
@@ -22,7 +22,6 @@
       <Control ID="Sequence">
         <Action
           ID="PlanCartesianPath"
-          acceleration_scale_factor="1.000000"
           blending_radius="0.020000"
           debug_solution="{debug_solution}"
           ik_cartesian_space_density="0.010000"
@@ -31,8 +30,7 @@
           path="{pose_stamped_vector}"
           position_only="false"
           tip_links="left_grasp_link;right_grasp_link"
-          trajectory_sampling_rate="100"
-          velocity_scale_factor="1.000000"
+          trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"
           tip_offset="0;0;0;0;0;0"
           planning_group_name="arms_only"

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
@@ -41,7 +41,6 @@
       <Control ID="Fallback">
         <Action
           ID="PlanCartesianPath"
-          acceleration_scale_factor="1.000000"
           blending_radius="0.020000"
           debug_solution="{debug_solution}"
           ik_cartesian_space_density="0.010000"
@@ -50,8 +49,7 @@
           path="{pose_stamped_vector}"
           position_only="false"
           tip_links="left_grasp_link;right_grasp_link"
-          trajectory_sampling_rate="100"
-          velocity_scale_factor="1.000000"
+          trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"
           tip_offset="0;0;0;0;0;0"
           planning_group_name="arms_only"

--- a/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
@@ -91,7 +91,6 @@
       <Control ID="Fallback">
         <Action
           ID="PlanCartesianPath"
-          acceleration_scale_factor="1.000000"
           blending_radius="0.020000"
           debug_solution="{debug_solution}"
           ik_cartesian_space_density="0.010000"
@@ -100,8 +99,7 @@
           path="{pose_stamped_vector}"
           position_only="false"
           tip_links="left_grasp_link"
-          trajectory_sampling_rate="100"
-          velocity_scale_factor="1.000000"
+          trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"
           tip_offset="0;0;0;0;0;0"
           planning_group_name="left_manipulator"


### PR DESCRIPTION
[written by AI]

## Problem

`PlanCartesianPath` now takes a single `trajectory_timing` input port that supersedes the deprecated `velocity_scale_factor`, `acceleration_scale_factor`, and `trajectory_sampling_rate` ports. Objectives that still set the deprecated ports log a warning on every run and will break once the ports are removed. The first-party example_ws Objectives were migrated in PickNikRobotics/moveit_pro_example_ws#752; the phoebe_sim Objectives vendored into example_ws are migrated here upstream so the change survives a submodule re-sync.

## Change

Migrated the 5 `PlanCartesianPath` nodes that set a deprecated port onto `trajectory_timing`. All 5 set only the default values (full scaling, 100 Hz), so each minimizes to `[{mode: time_optimal}]`. Behavior-preserving: each node resolves to the identical effective timing.

`multi-tip_path_re-orient_move_up_and_push.xml` is untouched: its scale factors live on `Move to Waypoint` SubTree nodes (a different Behavior's ports), and its own `PlanCartesianPath` node never set the deprecated ports.

Requires MoveIt Pro 10.0.0 or newer (`trajectory_timing` does not exist in 9.4.x / 8.10.x).

## Verification

- No `PlanCartesianPath` node under `src/phoebe_sim/objectives/` still sets a deprecated port; XML well-formed (xmllint); pre-commit clean.
- The rewrite matches the migrated all-default Objectives from PickNikRobotics/moveit_pro_example_ws#752 exactly.

## Relation to main

Same change as #31, targeting `for-example-ws-no-dups` so the `phoebe_ws` submodule pin in moveit_pro_example_ws can advance. The SHA bump follows in an example_ws PR after this merges.
