### PR TITLE
Migrate phoebe_sim hardware launch keys for MoveIt Pro 10.0

### DIFF
--- a/src/phoebe_sim/config/config.yaml
+++ b/src/phoebe_sim/config/config.yaml
@@ -1,6 +1,4 @@
 hardware:
-  simulated: true
-
   # If the MoveIt Pro Agent should launch the ros2 controller node.
   # [Optional, default=True]
   launch_control_node: True
@@ -9,10 +7,6 @@ hardware:
   # This should be false if you are launching the robot state publisher as part of drivers.
   # [Optional, default=True]
   launch_robot_state_publisher: True
-
-  robot_driver_persist_launch_file:
-    package: "moveit_studio_agent"
-    path: "launch/blank.launch.py"
 
   robot_description:
     urdf:


### PR DESCRIPTION
[written by AI]

## Motivation

Pairs with PickNikRobotics/moveit_pro#20990, which removes the `simulated`, `robot_driver_persist_launch_file`, `simulated_robot_driver_persist_launch_file`, and `simulated_hardware_launch_file` keys from the `config.yaml` `hardware` section in MoveIt Pro 10.0. `phoebe_sim` is consumed by `moveit_pro_example_ws` as a submodule, so its config must migrate for the example workspace to load under the new schema.

## Brief description

Removes `hardware.simulated` and the blank `hardware.robot_driver_persist_launch_file` block from `phoebe_sim/config/config.yaml`. Both were the blank default, so deleting them preserves runtime behavior; the new `additional_driver_launch_file` / `additional_agent_launch_file` keys default to blank and need not be set here.

The `moveit_pro_example_ws` PR bumps its submodule pointer to this branch's tip.
