### PR TITLE
Fix: Rename GetRobotJointState to GetJointState in record_admittance_trajectory

### DIFF
--- a/src/phoebe_sim/objectives/record_admittance_trajectory.xml
+++ b/src/phoebe_sim/objectives/record_admittance_trajectory.xml
@@ -20,7 +20,7 @@
         planning_scene_msg="{planning_scene}"
       />
       <Action
-        ID="GetRobotJointState"
+        ID="GetJointState"
         joint_state="{joint_state}"
         planning_scene="{planning_scene}"
         planning_group_name="right_manipulator"


### PR DESCRIPTION
[written by AI]

Renames the deprecated `GetRobotJointState` Behavior alias to `GetJointState` in `record_admittance_trajectory.xml`, matching the RobotState Behavior rename in PickNikRobotics/moveit_pro#20821.

This is the phoebe_ws submodule half of PickNikRobotics/moveit_pro#21016 (updating `moveit_pro_example_ws` objectives off the deprecated aliases). Once merged, the example_ws PR bumps this submodule and drops the deprecation flag from the Objective editor.
