### PR TITLE
Migrate phoebe_sim Objectives off the deprecated PlanCartesianPath position_only port

### DIFF
--- a/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_push_bottle.xml
@@ -53,7 +53,7 @@
           ik_joint_space_density="0.100000"
           joint_trajectory_msg="{joint_trajectory_msg}"
           path="{pose_stamped_vector}"
-          position_only="false"
+          cartesian_constraint="[{constraint_type: position_and_orientation}]"
           tip_links="left_grasp_link;right_grasp_link"
           trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_up_bottle.xml
@@ -53,7 +53,7 @@
           ik_joint_space_density="0.100000"
           joint_trajectory_msg="{joint_trajectory_msg}"
           path="{pose_stamped_vector}"
-          position_only="false"
+          cartesian_constraint="[{constraint_type: position_and_orientation}]"
           tip_links="left_grasp_link;right_grasp_link"
           trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"

--- a/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_move_with_pose.xml
@@ -28,7 +28,7 @@
           ik_joint_space_density="0.100000"
           joint_trajectory_msg="{joint_trajectory_msg}"
           path="{pose_stamped_vector}"
-          position_only="false"
+          cartesian_constraint="[{constraint_type: position_and_orientation}]"
           tip_links="left_grasp_link;right_grasp_link"
           trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"

--- a/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
+++ b/src/phoebe_sim/objectives/multi-tip_path_re-orient_bottle.xml
@@ -47,7 +47,7 @@
           ik_joint_space_density="0.100000"
           joint_trajectory_msg="{joint_trajectory_msg}"
           path="{pose_stamped_vector}"
-          position_only="false"
+          cartesian_constraint="[{constraint_type: position_and_orientation}]"
           tip_links="left_grasp_link;right_grasp_link"
           trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"

--- a/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
+++ b/src/phoebe_sim/objectives/single-tip_path_admittance_move_push_bottle.xml
@@ -97,7 +97,7 @@
           ik_joint_space_density="0.100000"
           joint_trajectory_msg="{joint_trajectory_msg}"
           path="{pose_stamped_vector}"
-          position_only="false"
+          cartesian_constraint="[{constraint_type: position_and_orientation}]"
           tip_links="left_grasp_link"
           trajectory_timing="[{mode: time_optimal}]"
           max_optimizer_iterations="1"


### PR DESCRIPTION
[written by AI]

## Problem

MoveIt Pro 10.0 deprecates the `position_only` port of `PlanCartesianPath` in favor of the `cartesian_constraint` port (the two are mutually exclusive), so Objectives that still set it log a deprecation warning on every run. The first-party example_ws Objectives were migrated in PickNikRobotics/moveit_pro_example_ws#853; the phoebe_sim Objectives vendored into example_ws are migrated here upstream so the change survives a submodule re-sync.

## Change

Replaced `position_only="false"` with `cartesian_constraint="[{constraint_type: position_and_orientation}]"` on the five `PlanCartesianPath` nodes that set it. Behavior-preserving: the literal selects the same constraint the bool expressed.

Requires MoveIt Pro 10.0.0 or newer (`cartesian_constraint` does not exist in 9.4.x / 8.10.x).

## Verification

No `position_only` attribute remains under `src/`; XML well-formed (xmllint); pre-commit clean. The replacement matches the migrated example_ws Objectives from PickNikRobotics/moveit_pro_example_ws#853 exactly.

Paired no-dups PR: #36.
